### PR TITLE
Updated vimrc to show current line number

### DIFF
--- a/.vimrc
+++ b/.vimrc
@@ -2,7 +2,7 @@ set nocompatible
 let mapleader=" "
 
 " relative numbers
-set rnu
+set rnu nu
 
 " tab support for :
 set showcmd


### PR DESCRIPTION
Might be helpful for debugging as people can tell you which line number they're on